### PR TITLE
Where is no consumer->isUsableBy function in REL1_26. Should be remov…

### DIFF
--- a/frontend/specialpages/SpecialMWOAuth.php
+++ b/frontend/specialpages/SpecialMWOAuth.php
@@ -155,10 +155,11 @@ class SpecialMWOAuth extends \UnlistedSpecialPage {
 							'mwoauth-invalid-authorization-wrong-wiki',
 							array( $wiki )
 						);
-					} elseif ( !$consumer->isUsableBy( $localUser ) ) {
-						throw new MWOAuthException( 'mwoauth-invalid-authorization-not-approved',
-							$consumer->get( 'name' ) );
-					}
+					};
+                    //  elseif ( !$consumer->isUsableBy( $localUser ) ) {
+					// 	throw new MWOAuthException( 'mwoauth-invalid-authorization-not-approved',
+					// 		$consumer->get( 'name' ) );
+					// }
 
 					// We know the identity of the user who granted the authorization
 					$this->outputJWT( $localUser, $consumer, $oauthRequest, $format, $access );


### PR DESCRIPTION
Where is no consumer->isUsableBy function in branch REL1_26. Should be just removed to work.